### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The developer needs to execute:
 
 ```
     $ ln -s $PWD/Makefile.toplevel $YOUR_PKG_PATH/Makefile
-    $ cd YOUR_PKG_PATH
+    $ cd $YOUR_PKG_PATH
     $ DIST_NAME=centos make build-rpm
 ```
 


### PR DESCRIPTION
This commit fixes a typo in README.md, minor change

Signed-off-by: Jesus Ornelas Aguayo <jesus.ornelas.aguayo@intel.com>